### PR TITLE
Update Vite config paths and add React plugin

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,8 @@ import { createServer } from "./server";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  root: "./leirisonda-deploy",
-  publicDir: "./leirisonda-deploy",
+  root: "./",
+  publicDir: "./public",
   server: {
     host: "::",
     port: 8080,
@@ -14,7 +14,7 @@ export default defineConfig(({ mode }) => ({
   build: {
     outDir: "dist/spa",
   },
-  plugins: [staticServePlugin()],
+  plugins: [react(), staticServePlugin()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./"),


### PR DESCRIPTION
This commit updates the Vite configuration with the following changes:

- Changed root directory from "./leirisonda-deploy" to "./"
- Updated publicDir from "./leirisonda-deploy" to "./public"
- Added react() plugin to the plugins array alongside existing staticServePlugin()

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1362bdf499be45f8ada6756b00bd3905/pulse-forge)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1362bdf499be45f8ada6756b00bd3905</projectId>-->
<!--<branchName>pulse-forge</branchName>-->