### PR TITLE
Reduce timeout values and improve navigation flow

### DIFF
--- a/components/ProtectedRoute.tsx
+++ b/components/ProtectedRoute.tsx
@@ -141,7 +141,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
           // Em caso de erro, ser conservador e recarregar em vez de redirecionar
           window.location.reload();
         }
-      }, 15000); // Aumentado para 15 segundos para dar mais tempo
+      }, 8000); // Reduzido para 8 segundos para evitar timeout longo
 
       return () => clearTimeout(timeout);
     }
@@ -162,13 +162,21 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
           localStorage.removeItem("work_created_timestamp");
           setJustCreatedWork(false);
           setIsRecoveringFromWorkCreation(false);
+
+          // Se ainda não temos usuário, forçar reload
+          if (!user) {
+            console.log(
+              "🔄 Forçando reload após cleanup - nenhum usuário encontrado",
+            );
+            window.location.reload();
+          }
         } catch (error) {
           console.warn("Erro ao limpar flags:", error);
         }
-      }, 20000); // 20 segundos para dar bastante tempo
+      }, 10000); // Reduzido para 10 segundos
 
       return () => clearTimeout(cleanupTimer);
-    }, []);
+    }, [user]);
 
     return (
       <div className="min-h-screen bg-gradient-to-br from-leirisonda-blue-light to-white flex items-center justify-center">
@@ -209,7 +217,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
         const sessionUser = sessionStorage.getItem("temp_user_session");
         const justCreated = sessionStorage.getItem("just_created_work");
 
-        // Se há qualquer indicação de sessão válida
+        // Se há qualquer indicação de sessão v��lida
         if (storedUser || sessionUser || justCreated === "true") {
           console.log(
             "🔄 Sessão detectada, tentativa de recuperação:",
@@ -265,6 +273,14 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
                     ? "A sincronizar com o servidor..."
                     : "Se demorar muito, será redirecionado automaticamente..."}
               </p>
+              {recoveryAttempts >= 2 && (
+                <button
+                  onClick={() => window.location.reload()}
+                  className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm"
+                >
+                  Recarregar Agora
+                </button>
+              )}
             </div>
           </div>
         );

--- a/pages/CreateWork.tsx
+++ b/pages/CreateWork.tsx
@@ -442,28 +442,19 @@ export function CreateWork() {
           try {
             console.log("🏠 Navegando para Dashboard após obra criada");
 
-            // Dar tempo para a sessão ser totalmente preservada
-            setTimeout(() => {
-              // Usar replace para evitar histórico de navegação problemático
-              navigate("/dashboard", { replace: true });
+            // Limpar flags problemáticas imediatamente
+            sessionStorage.removeItem("just_created_work");
+            localStorage.removeItem("work_created_timestamp");
 
-              // Verificação de segurança mais rápida
-              setTimeout(() => {
-                if (window.location.pathname.includes("/create-work")) {
-                  console.warn(
-                    "🔄 Navigate demorou, tentando window.location...",
-                  );
-                  window.location.href = "/dashboard";
-                }
-              }, 1500);
-            }, 500); // Reduzir delay inicial
+            // Usar window.location diretamente para evitar problemas de navegação
+            setTimeout(() => {
+              window.location.href = "/dashboard";
+            }, 200); // Delay muito reduzido
           } catch (navError) {
             console.warn("❌ Erro na navegação, usando fallback:", navError);
 
-            // FALLBACK: Usar window.location diretamente
-            setTimeout(() => {
-              window.location.href = "/dashboard";
-            }, 500);
+            // FALLBACK: Forçar navegação
+            window.location.href = "/dashboard";
           }
         } catch (err) {
           console.error("❌ ERRO AO CRIAR OBRA:", err);


### PR DESCRIPTION
This change reduces timeout values and improves navigation flow in the ProtectedRoute and CreateWork components.

Changes made:
- Reduced timeout from 15 seconds to 8 seconds in ProtectedRoute recovery logic
- Reduced cleanup timer from 20 seconds to 10 seconds
- Added user dependency to useEffect hook in ProtectedRoute
- Added forced reload when no user is found after cleanup
- Added manual reload button when recovery attempts >= 2
- Simplified navigation flow in CreateWork by removing nested timeouts
- Changed to use window.location.href directly with reduced delay (200ms)
- Added immediate cleanup of session flags before navigation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1362bdf499be45f8ada6756b00bd3905/vortex-verse)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1362bdf499be45f8ada6756b00bd3905</projectId>-->
<!--<branchName>vortex-verse</branchName>-->